### PR TITLE
Fix prisma schema not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY package.json package-lock.json* ./
+# Copy Prisma schema for postinstall script
+COPY prisma ./prisma
 RUN npm ci
 
 # Rebuild the source code only when needed

--- a/package.json
+++ b/package.json
@@ -33,8 +33,5 @@
     "tailwindcss": "^4",
     "tsx": "^4.7.0",
     "typescript": "^5"
-  },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
   }
 }

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from '@prisma/client/generator';
+
+export default defineConfig({
+  schema: './prisma/schema.prisma',
+  seed: 'tsx prisma/seed.ts'
+});


### PR DESCRIPTION
Fixes Render deployment failure by ensuring Prisma schema is available during build and migrating deprecated Prisma configuration.

The deployment failed because `prisma generate`, run via a `postinstall` script during `npm ci` in the Docker build, could not find the `schema.prisma` file. This PR copies the `prisma` directory earlier in the `Dockerfile` to resolve this. Additionally, the deprecated Prisma configuration in `package.json` was migrated to `prisma.config.ts` to address a warning and follow best practices.

---
<a href="https://cursor.com/background-agent?bcId=bc-23073459-c2ea-44ab-855a-30fde2fd2580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23073459-c2ea-44ab-855a-30fde2fd2580">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

