### PR TITLE
Fix prisma generate module not found error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY package.json package-lock.json* ./
 # Copy Prisma schema for postinstall script
 COPY prisma ./prisma
-RUN npm ci
+RUN npm ci --verbose
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -17,8 +17,9 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
-# Generate Prisma Client
-RUN npx prisma generate
+# Ensure Prisma dependencies are available and generate client
+RUN npx prisma --version
+RUN npx prisma generate --schema=./prisma/schema.prisma
 
 # Build the application
 RUN npm run build

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "db:migrate": "prisma migrate dev",
     "db:seed": "tsx prisma/seed.ts",
     "db:reset": "prisma migrate reset --force",
-    "postinstall": "if [ \"$NODE_ENV\" != \"production\" ]; then prisma generate; fi"
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@prisma/client": "^6.14.0",


### PR DESCRIPTION
Ensures Prisma client is generated correctly during Docker builds to fix deployment errors.

The deployment failed because the Prisma client was not generated in the production environment due to a conditional `postinstall` script and an implicit schema path in the Dockerfile. This PR removes the condition and explicitly defines the schema path, ensuring the client is always available.

---
<a href="https://cursor.com/background-agent?bcId=bc-368f50f6-0771-41dd-9a28-51699165b799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-368f50f6-0771-41dd-9a28-51699165b799">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

