### PR TITLE
Optimize prisma client generation in docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,8 @@ COPY . .
 # Diagnostic step to verify dependencies are present
 RUN npm ls @prisma/client prisma --depth=0 || true
 
-# Generate Prisma client after copying source code
-RUN npx prisma generate --schema=./prisma/schema.prisma
+# Health check: Verify Prisma Client was generated correctly in deps stage
+RUN node -e "require('@prisma/client'); console.log('Prisma Client OK')"
 
 # Build the application
 RUN npm run build


### PR DESCRIPTION
Remove redundant Prisma Client generation in Dockerfile builder stage and add a health check.

The `npx prisma generate` command in the builder stage was failing because Prisma Client was already generated by `postinstall` in the `deps` stage, leading to a "Cannot find module" error. This change ensures Prisma Client is generated exactly once.

---
<a href="https://cursor.com/background-agent?bcId=bc-c991803e-30cb-49d4-9a33-37db0ccf3620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c991803e-30cb-49d4-9a33-37db0ccf3620">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

