### PR TITLE
Fix prisma config import for nextjs type checking

### DIFF
--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,6 +1,5 @@
-import { defineConfig } from '@prisma/client/generator';
+import { defineConfig } from 'prisma/config';
 
 export default defineConfig({
-  schema: './prisma/schema.prisma',
-  seed: 'tsx prisma/seed.ts'
+  schema: './prisma/schema.prisma'
 });


### PR DESCRIPTION
Update Prisma config to use public API and remove invalid `seed` option to fix build errors.

The original import `import { defineConfig } from '@prisma/client/generator';` was an internal module causing a `Type error: Cannot find module` during Next.js type-checking. The `seed` property was also removed as it is not a valid configuration option for `defineConfig` in Prisma v6.

---
<a href="https://cursor.com/background-agent?bcId=bc-06a6dc5d-9c3a-4357-a5c7-9d69212fc472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-06a6dc5d-9c3a-4357-a5c7-9d69212fc472">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

