### PR TITLE
Make snsLink unique in Cast model

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,7 +13,7 @@ datasource db {
 model Cast {
   id          String   @id @default(cuid())
   name        String
-  snsLink     String
+  snsLink     String   @unique
   storeLink   String?
   area        Area
   serviceType ServiceType


### PR DESCRIPTION
Make `snsLink` unique in the `Cast` model to enable valid `upsert` operations in `seed.ts`.

The `prisma.cast.upsert` operation requires a `CastWhereUniqueInput` for its `where` clause. Previously, `snsLink` was not unique, causing a type-checking error. Adding `@unique` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-153117e4-81fc-4123-830c-aa5e83c599c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-153117e4-81fc-4123-830c-aa5e83c599c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

