### PR TITLE
Separate form value and error types

### DIFF
--- a/src/app/admin/add-cast/page.tsx
+++ b/src/app/admin/add-cast/page.tsx
@@ -15,6 +15,15 @@ interface FormData {
   budgetRange: BudgetRange | ''
 }
 
+interface FormErrors {
+  name?: string
+  snsLink?: string
+  storeLink?: string
+  area?: string
+  serviceType?: string
+  budgetRange?: string
+}
+
 export default function AddCastPage() {
   const router = useRouter()
   const [formData, setFormData] = useState<FormData>({
@@ -26,10 +35,10 @@ export default function AddCastPage() {
     budgetRange: ''
   })
   const [loading, setLoading] = useState(false)
-  const [errors, setErrors] = useState<Partial<FormData>>({})
+  const [errors, setErrors] = useState<FormErrors>({})
 
   const validateForm = (): boolean => {
-    const newErrors: Partial<FormData> = {}
+    const newErrors: FormErrors = {}
 
     if (!formData.name.trim()) {
       newErrors.name = 'キャスト名は必須です'


### PR DESCRIPTION
Separates form value types from error message types to resolve a TypeScript compile error where string error messages were incorrectly assigned to form value fields.

The `newErrors` object was previously typed as `Partial<FormData>`, which meant its properties expected form values (e.g., `Area | '' | undefined`). This caused a type error when assigning a string like `'エリアを選択してください'` to `newErrors.area`. By introducing a `FormErrors` interface with `string | undefined` for error fields, we ensure type correctness for error messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-63317983-7555-49d6-a925-bc68cfe2ea85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-63317983-7555-49d6-a925-bc68cfe2ea85">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

