### PR TITLE
Fix debug console display in admin

### DIFF
--- a/prisma/migrations/20250816114738_add_area_masters_table/migration.sql
+++ b/prisma/migrations/20250816114738_add_area_masters_table/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "area_masters" (
+    "id" TEXT NOT NULL,
+    "key" TEXT NOT NULL,
+    "label" TEXT NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "sortOrder" INTEGER NOT NULL DEFAULT 0,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "area_masters_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "area_masters_key_key" ON "area_masters"("key");

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -21,6 +21,30 @@ async function main() {
 
   console.log('管理者アカウントを作成しました:', admin.email)
 
+  // エリアマスターデータを作成
+  const sampleAreas = [
+    { key: 'SHIBUYA', label: '渋谷', sortOrder: 0 },
+    { key: 'SHINJUKU', label: '新宿', sortOrder: 1 },
+    { key: 'GINZA', label: '銀座', sortOrder: 2 },
+    { key: 'ROPPONGI', label: '六本木', sortOrder: 3 },
+    { key: 'IKEBUKURO', label: '池袋', sortOrder: 4 },
+    { key: 'AKASAKA', label: '赤坂', sortOrder: 5 },
+    { key: 'KABUKICHO', label: '歌舞伎町', sortOrder: 6 },
+    { key: 'OTHER', label: 'その他', sortOrder: 7 }
+  ]
+
+  for (const areaData of sampleAreas) {
+    const area = await prisma.areaMaster.upsert({
+      where: { key: areaData.key },
+      update: {},
+      create: {
+        ...areaData,
+        isActive: true
+      }
+    })
+    console.log('エリアを作成しました:', area.label)
+  }
+
   // サンプルキャストデータを作成
   const sampleCasts = [
     {

--- a/src/app/admin/add-cast/page.tsx
+++ b/src/app/admin/add-cast/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Area, ServiceType, BudgetRange, SERVICE_TYPE_LABELS, BUDGET_RANGE_LABELS } from '@/types'
 import { useAreas } from '@/hooks/useAreas'
+import { MobileConsole } from '@/components/MobileConsole'
 
 interface FormData {
   name: string
@@ -37,6 +38,7 @@ export default function AddCastPage() {
     budgetRange: ''
   })
   const [loading, setLoading] = useState(false)
+  const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false)
   const [errors, setErrors] = useState<FormErrors>({})
 
   const validateForm = (): boolean => {
@@ -163,12 +165,21 @@ export default function AddCastPage() {
             <h1 className="text-4xl font-bold glow-text mb-2">新しいキャストを追加</h1>
             <p className="text-gray-300">キャスト情報を入力してください</p>
           </div>
-          <Button 
-            onClick={() => router.push('/admin')}
-            variant="outline"
-          >
-            管理者ページに戻る
-          </Button>
+          <div className="flex gap-4">
+            <Button 
+              onClick={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)}
+              variant="outline"
+              className="text-yellow-400 border-yellow-400 hover:bg-yellow-400 hover:text-black"
+            >
+              🐛 デバッグコンソール
+            </Button>
+            <Button 
+              onClick={() => router.push('/admin')}
+              variant="outline"
+            >
+              管理者ページに戻る
+            </Button>
+          </div>
         </div>
 
         {/* フォーム */}
@@ -339,6 +350,12 @@ export default function AddCastPage() {
           </Card>
         </div>
       </div>
+
+      {/* デバッグコンソール */}
+      <MobileConsole 
+        isOpen={isDebugConsoleOpen} 
+        onToggle={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)} 
+      />
     </div>
   )
 }

--- a/src/app/admin/areas/page.tsx
+++ b/src/app/admin/areas/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation'
 import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { AreaMaster } from '@/types'
-import { mobileLog } from '@/components/MobileConsole'
+import { mobileLog, MobileConsole } from '@/components/MobileConsole'
 
 interface FormData {
   key: string
@@ -33,6 +33,7 @@ export default function AreasManagementPage() {
   })
   const [formErrors, setFormErrors] = useState<FormErrors>({})
   const [submitting, setSubmitting] = useState(false)
+  const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false)
 
   useEffect(() => {
     fetchAreas()
@@ -262,6 +263,13 @@ export default function AreasManagementPage() {
               新しいエリアを追加
             </Button>
             <Button 
+              onClick={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)}
+              variant="outline"
+              className="text-yellow-400 border-yellow-400 hover:bg-yellow-400 hover:text-black"
+            >
+              🐛 デバッグコンソール
+            </Button>
+            <Button 
               onClick={() => router.push('/admin')}
               variant="outline"
             >
@@ -439,6 +447,12 @@ export default function AreasManagementPage() {
           )}
         </div>
       </div>
+
+      {/* デバッグコンソール */}
+      <MobileConsole 
+        isOpen={isDebugConsoleOpen} 
+        onToggle={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)} 
+      />
     </div>
   )
 }

--- a/src/app/admin/edit-cast/[id]/page.tsx
+++ b/src/app/admin/edit-cast/[id]/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Area, ServiceType, BudgetRange, SERVICE_TYPE_LABELS, BUDGET_RANGE_LABELS, Cast } from '@/types'
 import { useAreas } from '@/hooks/useAreas'
+import { MobileConsole } from '@/components/MobileConsole'
 
 interface FormData {
   name: string
@@ -40,6 +41,7 @@ export default function EditCastPage() {
     budgetRange: ''
   })
   const [loading, setLoading] = useState(false)
+  const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false)
   const [initialLoading, setInitialLoading] = useState(true)
   const [errors, setErrors] = useState<FormErrors>({})
   const [cast, setCast] = useState<Cast | null>(null)
@@ -216,12 +218,21 @@ export default function EditCastPage() {
             <h1 className="text-4xl font-bold glow-text mb-2">キャスト情報を編集</h1>
             <p className="text-gray-300">{cast.name} の情報を更新</p>
           </div>
-          <Button 
-            onClick={() => router.push('/admin')}
-            variant="outline"
-          >
-            管理者ページに戻る
-          </Button>
+          <div className="flex gap-4">
+            <Button 
+              onClick={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)}
+              variant="outline"
+              className="text-yellow-400 border-yellow-400 hover:bg-yellow-400 hover:text-black"
+            >
+              🐛 デバッグコンソール
+            </Button>
+            <Button 
+              onClick={() => router.push('/admin')}
+              variant="outline"
+            >
+              管理者ページに戻る
+            </Button>
+          </div>
         </div>
 
         {/* フォーム */}
@@ -392,6 +403,12 @@ export default function EditCastPage() {
           </Card>
         </div>
       </div>
+
+      {/* デバッグコンソール */}
+      <MobileConsole 
+        isOpen={isDebugConsoleOpen} 
+        onToggle={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)} 
+      />
     </div>
   )
 }

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button'
 import { Card } from '@/components/ui/Card'
 import { Cast, SERVICE_TYPE_LABELS, BUDGET_RANGE_LABELS } from '@/types'
 import { useAreas } from '@/hooks/useAreas'
+import { MobileConsole, MobileConsoleToggle } from '@/components/MobileConsole'
 
 export default function AdminPage() {
   const router = useRouter()
@@ -13,6 +14,7 @@ export default function AdminPage() {
   const [casts, setCasts] = useState<Cast[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [isDebugConsoleOpen, setIsDebugConsoleOpen] = useState(false)
 
   useEffect(() => {
     fetchCasts()
@@ -123,6 +125,13 @@ export default function AdminPage() {
               variant="secondary"
             >
               エリア管理
+            </Button>
+            <Button 
+              onClick={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)}
+              variant="outline"
+              className="text-yellow-400 border-yellow-400 hover:bg-yellow-400 hover:text-black"
+            >
+              🐛 デバッグコンソール
             </Button>
             <Button 
               onClick={() => router.push('/')}
@@ -258,6 +267,12 @@ export default function AdminPage() {
           )}
         </div>
       </div>
+
+      {/* デバッグコンソール */}
+      <MobileConsole 
+        isOpen={isDebugConsoleOpen} 
+        onToggle={() => setIsDebugConsoleOpen(!isDebugConsoleOpen)} 
+      />
     </div>
   )
 }


### PR DESCRIPTION
Fixes missing `area_masters` table error and adds debug console to admin pages.

The `area_masters` table was defined in the Prisma schema but was missing from the database, causing `P2021` errors on the area registration page. This PR adds the necessary migration and initial seed data. The debug console is integrated into admin pages to provide real-time error monitoring and troubleshooting capabilities.

---
<a href="https://cursor.com/background-agent?bcId=bc-e8c1cbcf-4598-4aa9-9a46-dee25a5f7188">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e8c1cbcf-4598-4aa9-9a46-dee25a5f7188">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

