### PR TITLE
Fix nextjs build type error

### DIFF
--- a/src/app/results/results-client.tsx
+++ b/src/app/results/results-client.tsx
@@ -298,7 +298,9 @@ export function ResultsClient() {
               className="rounded-full p-4 shadow-gaming"
               glow
               icon={<ArrowLeft className="w-6 h-6" />}
-            />
+            >
+              ホームに戻る
+            </Button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add missing `children` prop to `Button` component to resolve a TypeScript compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-d0dd83ee-5504-4665-bed3-dd842dc0b007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d0dd83ee-5504-4665-bed3-dd842dc0b007">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

