### PR TITLE
Seed database with area data

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -51,49 +51,49 @@ async function main() {
       name: '美咲',
       snsLink: 'https://twitter.com/misaki_cast',
       storeLink: 'https://example-store1.com',
-      area: 'SHIBUYA',
-      serviceType: 'KYABA',
-      budgetRange: 'FROM_20K_TO_30K'
+      area: '渋谷',
+      serviceType: 'キャバクラ',
+      budgetRange: '20,000円〜30,000円'
     },
     {
       name: 'あやか',
       snsLink: 'https://instagram.com/ayaka_cast',
       storeLink: 'https://example-store2.com',
-      area: 'SHINJUKU',
-      serviceType: 'GIRLS_BAR',
-      budgetRange: 'FROM_10K_TO_20K'
+      area: '新宿',
+      serviceType: 'ガールズバー',
+      budgetRange: '10,000円〜20,000円'
     },
     {
       name: 'ゆい',
       snsLink: 'https://twitter.com/yui_cast',
       storeLink: null,
-      area: 'GINZA',
-      serviceType: 'LOUNGE',
-      budgetRange: 'FROM_30K_TO_50K'
+      area: '銀座',
+      serviceType: 'ラウンジ',
+      budgetRange: '30,000円〜50,000円'
     },
     {
       name: 'りな',
       snsLink: 'https://instagram.com/rina_cast',
       storeLink: 'https://example-store3.com',
-      area: 'ROPPONGI',
-      serviceType: 'CLUB',
-      budgetRange: 'OVER_50K'
+      area: '六本木',
+      serviceType: 'クラブ',
+      budgetRange: '50,000円以上'
     },
     {
       name: 'さくら',
       snsLink: 'https://twitter.com/sakura_cast',
       storeLink: 'https://example-store4.com',
-      area: 'IKEBUKURO',
-      serviceType: 'SNACK',
-      budgetRange: 'UNDER_10K'
+      area: '池袋',
+      serviceType: 'スナック',
+      budgetRange: '10,000円未満'
     },
     {
       name: 'まい',
       snsLink: 'https://instagram.com/mai_cast',
       storeLink: null,
-      area: 'AKASAKA',
-      serviceType: 'KYABA',
-      budgetRange: 'FROM_20K_TO_30K'
+      area: '赤坂',
+      serviceType: 'キャバクラ',
+      budgetRange: '20,000円〜30,000円'
     }
   ]
 
@@ -103,9 +103,6 @@ async function main() {
       update: {},
       create: {
         ...castData,
-        area: castData.area as any,
-        serviceType: castData.serviceType as any,
-        budgetRange: castData.budgetRange as any,
         isActive: true
       }
     })


### PR DESCRIPTION
Update `Cast` model seed data to use correct string values, resolving a Prisma type mismatch error (P2032) during seeding.

The `area`, `serviceType`, and `budgetRange` fields in the `Cast` model are defined as `String` types in the Prisma schema. The seed file was attempting to insert enum-like constants (e.g., 'SHIBUYA') which caused a type conversion error. This PR updates the seed data to use the expected human-readable string values (e.g., '渋谷').

---
<a href="https://cursor.com/background-agent?bcId=bc-e68d5d27-9547-427d-8675-3ffeb053b87f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e68d5d27-9547-427d-8675-3ffeb053b87f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

