### PR TITLE
Fix prisma area field type mismatch

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -46,13 +46,13 @@ async function main() {
   }
 
   // サンプルキャストデータを作成
-  // エリア名は AreaMaster の label を使用（String フィールドに合わせる）
+  // エリア名は Area enum のキー値を使用（String フィールドだが enum キーを格納）
   const sampleCasts = [
     {
       name: '美咲',
       snsLink: 'https://twitter.com/misaki_cast',
       storeLink: 'https://example-store1.com',
-      area: '渋谷', // AreaMaster の label を使用
+      area: 'SHIBUYA', // Area enum キーを使用
       serviceType: 'KYABA',
       budgetRange: 'FROM_20K_TO_30K'
     },
@@ -60,7 +60,7 @@ async function main() {
       name: 'あやか',
       snsLink: 'https://instagram.com/ayaka_cast',
       storeLink: 'https://example-store2.com',
-      area: '新宿', // AreaMaster の label を使用
+      area: 'SHINJUKU', // Area enum キーを使用
       serviceType: 'GIRLS_BAR',
       budgetRange: 'FROM_10K_TO_20K'
     },
@@ -68,7 +68,7 @@ async function main() {
       name: 'ゆい',
       snsLink: 'https://twitter.com/yui_cast',
       storeLink: null,
-      area: '銀座', // AreaMaster の label を使用
+      area: 'GINZA', // Area enum キーを使用
       serviceType: 'LOUNGE',
       budgetRange: 'FROM_30K_TO_50K'
     },
@@ -76,7 +76,7 @@ async function main() {
       name: 'りな',
       snsLink: 'https://instagram.com/rina_cast',
       storeLink: 'https://example-store3.com',
-      area: '六本木', // AreaMaster の label を使用
+      area: 'ROPPONGI', // Area enum キーを使用
       serviceType: 'CLUB',
       budgetRange: 'OVER_50K'
     },
@@ -84,7 +84,7 @@ async function main() {
       name: 'さくら',
       snsLink: 'https://twitter.com/sakura_cast',
       storeLink: 'https://example-store4.com',
-      area: '池袋', // AreaMaster の label を使用
+      area: 'IKEBUKURO', // Area enum キーを使用
       serviceType: 'SNACK',
       budgetRange: 'UNDER_10K'
     },
@@ -92,7 +92,7 @@ async function main() {
       name: 'まい',
       snsLink: 'https://instagram.com/mai_cast',
       storeLink: null,
-      area: '赤坂', // AreaMaster の label を使用
+      area: 'AKASAKA', // Area enum キーを使用
       serviceType: 'KYABA',
       budgetRange: 'FROM_20K_TO_30K'
     }


### PR DESCRIPTION
Update `prisma/seed.ts` to use English enum keys for `area` field to resolve deployment errors.

The `Cast` model's `area` field, while a `String` in the Prisma schema, was receiving Japanese labels from the seed file, leading to a `P2032` type conversion error (`found: 'SHIBUYA'`). This change aligns the seed data with the expected English enum key format.

---
<a href="https://cursor.com/background-agent?bcId=bc-86227972-bf6c-4195-a7f5-0b5ae6dd95ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86227972-bf6c-4195-a7f5-0b5ae6dd95ec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

