### PR TITLE
Fix area field type mismatch in seed data

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,17 +10,46 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
+// PostgreSQL supports enums, and we use them for type safety
+enum Area {
+  SHIBUYA
+  SHINJUKU
+  GINZA
+  ROPPONGI
+  IKEBUKURO
+  AKASAKA
+  KABUKICHO
+  OTHER
+}
+
+enum ServiceType {
+  KYABA
+  GIRLS_BAR
+  SNACK
+  LOUNGE
+  CLUB
+  OTHER
+}
+
+enum BudgetRange {
+  UNDER_10K
+  FROM_10K_TO_20K
+  FROM_20K_TO_30K
+  FROM_30K_TO_50K
+  OVER_50K
+}
+
 model Cast {
-  id          String   @id @default(cuid())
+  id          String      @id @default(cuid())
   name        String
-  snsLink     String   @unique
+  snsLink     String      @unique
   storeLink   String?
-  area        String
-  serviceType String
-  budgetRange String
-  isActive    Boolean  @default(true)
-  createdAt   DateTime @default(now())
-  updatedAt   DateTime @updatedAt
+  area        Area
+  serviceType ServiceType
+  budgetRange BudgetRange
+  isActive    Boolean     @default(true)
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
 
   @@map("casts")
 }
@@ -47,32 +76,3 @@ model Admin {
 
   @@map("admins")
 }
-
-// PostgreSQL supports enums, but we keep them as strings for compatibility
-// enum Area {
-//   SHIBUYA
-//   SHINJUKU
-//   GINZA
-//   ROPPONGI
-//   IKEBUKURO
-//   AKASAKA
-//   KABUKICHO
-//   OTHER
-// }
-
-// enum ServiceType {
-//   KYABA
-//   GIRLS_BAR
-//   SNACK
-//   LOUNGE
-//   CLUB
-//   OTHER
-// }
-
-// enum BudgetRange {
-//   UNDER_10K
-//   FROM_10K_TO_20K
-//   FROM_20K_TO_30K
-//   FROM_30K_TO_50K
-//   OVER_50K
-// }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,5 @@
-import { PrismaClient } from '@prisma/client'
-import bcrypt from 'bcryptjs'
+import { PrismaClient, Area, ServiceType, BudgetRange } from '@prisma/client'
+import * as bcrypt from 'bcryptjs'
 
 const prisma = new PrismaClient()
 
@@ -46,55 +46,55 @@ async function main() {
   }
 
   // サンプルキャストデータを作成
-  // エリア名は Area enum のキー値を使用（String フィールドだが enum キーを格納）
+  // エナム値を直接使用
   const sampleCasts = [
     {
       name: '美咲',
       snsLink: 'https://twitter.com/misaki_cast',
       storeLink: 'https://example-store1.com',
-      area: 'SHIBUYA', // Area enum キーを使用
-      serviceType: 'KYABA',
-      budgetRange: 'FROM_20K_TO_30K'
+      area: Area.SHIBUYA, // Areaエナムを使用
+      serviceType: ServiceType.KYABA,
+      budgetRange: BudgetRange.FROM_20K_TO_30K
     },
     {
       name: 'あやか',
       snsLink: 'https://instagram.com/ayaka_cast',
       storeLink: 'https://example-store2.com',
-      area: 'SHINJUKU', // Area enum キーを使用
-      serviceType: 'GIRLS_BAR',
-      budgetRange: 'FROM_10K_TO_20K'
+      area: Area.SHINJUKU, // Areaエナムを使用
+      serviceType: ServiceType.GIRLS_BAR,
+      budgetRange: BudgetRange.FROM_10K_TO_20K
     },
     {
       name: 'ゆい',
       snsLink: 'https://twitter.com/yui_cast',
       storeLink: null,
-      area: 'GINZA', // Area enum キーを使用
-      serviceType: 'LOUNGE',
-      budgetRange: 'FROM_30K_TO_50K'
+      area: Area.GINZA, // Areaエナムを使用
+      serviceType: ServiceType.LOUNGE,
+      budgetRange: BudgetRange.FROM_30K_TO_50K
     },
     {
       name: 'りな',
       snsLink: 'https://instagram.com/rina_cast',
       storeLink: 'https://example-store3.com',
-      area: 'ROPPONGI', // Area enum キーを使用
-      serviceType: 'CLUB',
-      budgetRange: 'OVER_50K'
+      area: Area.ROPPONGI, // Areaエナムを使用
+      serviceType: ServiceType.CLUB,
+      budgetRange: BudgetRange.OVER_50K
     },
     {
       name: 'さくら',
       snsLink: 'https://twitter.com/sakura_cast',
       storeLink: 'https://example-store4.com',
-      area: 'IKEBUKURO', // Area enum キーを使用
-      serviceType: 'SNACK',
-      budgetRange: 'UNDER_10K'
+      area: Area.IKEBUKURO, // Areaエナムを使用
+      serviceType: ServiceType.SNACK,
+      budgetRange: BudgetRange.UNDER_10K
     },
     {
       name: 'まい',
       snsLink: 'https://instagram.com/mai_cast',
       storeLink: null,
-      area: 'AKASAKA', // Area enum キーを使用
-      serviceType: 'KYABA',
-      budgetRange: 'FROM_20K_TO_30K'
+      area: Area.AKASAKA, // Areaエナムを使用
+      serviceType: ServiceType.KYABA,
+      budgetRange: BudgetRange.FROM_20K_TO_30K
     }
   ]
 


### PR DESCRIPTION
Enable Prisma enums and update the `Cast` model and seed data to use them.

This fixes a `P2032` type mismatch error during seeding by ensuring type consistency between the Prisma schema and the seed data. The `Cast` model's `area`, `serviceType`, and `budgetRange` fields were previously `String` types, but the seed file was attempting to insert enum-like string values, causing a conversion error. By activating the corresponding enums in `schema.prisma` and using them directly in `seed.ts`, type safety is achieved.

---
<a href="https://cursor.com/background-agent?bcId=bc-f766b530-9438-427d-bb19-f85bb1848a14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f766b530-9438-427d-bb19-f85bb1848a14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

